### PR TITLE
Fix server port configuration

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -56,10 +56,10 @@ app.use((req, res, next) => {
     serveStatic(app);
   }
 
-  // ALWAYS serve the app on port 5000
-  // this serves both the API and the client.
-  // It is the only port that is not firewalled.
-  const port = 5000;
+  // Serve the app using the port provided via the PORT environment
+  // variable, defaulting to 5000 if not specified. This serves both the
+  // API and the client and is the only port that is not firewalled.
+  const port = Number(process.env.PORT) || 5000;
   server.listen({
     port,
     host: "0.0.0.0",


### PR DESCRIPTION
## Summary
- use `Number(process.env.PORT) || 5000` for the server port

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' & 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68430ad7c7ac8332846e0aca695a1f3f