### PR TITLE
Set Vite build output to dist/public

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,7 +31,7 @@ export default async () => {
     },
     root: path.resolve(__dirname, "client"),
     build: {
-      outDir: path.resolve(__dirname, "dist"), // ⬅️ simplified for Vercel
+      outDir: path.resolve(__dirname, "dist", "public"),
       emptyOutDir: true,
     },
     server: {


### PR DESCRIPTION
## Summary
- adjust `outDir` in `vite.config.ts` to align with `serveStatic`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430ada3a7483328f039d2b37443cb1